### PR TITLE
Added i18n support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 	"require": {
 		"php": ">=5.4.0",
 		"tinymce/tinymce": "^4.5.6",
+		"tweeb/tinymce-i18n": "^1.8.0",
 		"yiisoft/yii": "~1.1.18"
 	},
 	"autoload": {

--- a/src/TinyMceWidget.php
+++ b/src/TinyMceWidget.php
@@ -52,6 +52,11 @@ class TinyMceWidget extends CInputWidget {
 	public $fileManager = false;
 
 	/**
+	 * @var bool Whether widget should be localized using `Yii::app()->lang`.
+	 */
+	public $localized = true;
+
+	/**
 	 * Default widget configuration.
 	 *
 	 * @var array
@@ -119,6 +124,11 @@ class TinyMceWidget extends CInputWidget {
 	 */
 	private $tinymceAssetsDir;
 
+        /**
+         * @var string
+         */
+        private $tinymceLangsDir;
+
 	/**
 	 * {@inheritdoc}
 	 *
@@ -126,6 +136,10 @@ class TinyMceWidget extends CInputWidget {
 	 */
 	public function init() {
 		$this->tinymceAssetsDir = Yii::app()->assetManager->publish(Yii::getPathOfAlias('vendor.tinymce.tinymce'));
+		if($this->localized) {
+			$this->tinymceLangsDir = Yii::app()->assetManager->publish(Yii::getPathOfAlias('vendor.tweeb.tinymce-i18n.langs'));
+			$this->defaultSettings['language_url'] = $this->tinymceLangsDir . '/' . Yii::app()->language . '.js';
+		}
 
 		$this->settings = CMap::mergeArray($this->defaultSettings, $this->settings);
 	}


### PR DESCRIPTION
Added 'localized' attribute. If it is 'true', a respective language file is used from the 'tweeb/tinymce-i18n' package